### PR TITLE
Fixing click handler issue and moving class names around a bit.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,7 +39,7 @@
                     <p>I'm calling to ask Representative <span id="rep-name"></span> to publicly speak out against the Trans-Pacific Partnership and against a lame-duck vote on the TPP this fall. This corporate trade deal would exploit workers, offshore jobs, harm the environment and make medicines harder to get, among other things. Can I count on Rep. <span id="rep-name"></span> to publicly oppose the TPP and speak out against a lame duck vote?</p>
                   </div>
 
-                  <button class="call-key-rep" id="how-did-it-go">How'd it go? &#9654; </button>
+                  <button class="action-button" id="how-did-it-go">How'd it go? &#9654; </button>
                 </div>
 
                 <div id="page-2" class="modal-page page-2">

--- a/css/credohousecalls.css
+++ b/css/credohousecalls.css
@@ -285,7 +285,7 @@
 
     }
 
-    .call-key-rep {
+    .action-button {
         font-size:18px;
         margin-bottom:25px;
         width:100%;
@@ -556,7 +556,7 @@
             padding-left:0;
         }
 
-        .call-key-rep {
+        .action-button {
             width:auto;
             min-width: 250px;
         }

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@ title: Home
 
             </div>
 
-            <button data-id="A000373" class="call-key-rep">Call Rep. Ashford</button>
+            <button data-id="A000373" class="call-key-rep action-button">Call Rep. Ashford</button>
 
             <div style="clear: both;"></div>
 
@@ -127,7 +127,7 @@ title: Home
 
             </div>
 
-            <button data-id="B001287" class="call-key-rep">Call Rep. Bera</button>
+            <button data-id="B001287" class="call-key-rep action-button">Call Rep. Bera</button>
 
             <div style="clear: both;"></div>
 
@@ -149,7 +149,7 @@ title: Home
 
             </div>
 
-            <button data-id="B001292" class="call-key-rep">Call Rep. Beyer</button>
+            <button data-id="B001292" class="call-key-rep action-button">Call Rep. Beyer</button>
 
             <div style="clear: both;"></div>
 
@@ -171,7 +171,7 @@ title: Home
 
             </div>
 
-            <button data-id="B000574" class="call-key-rep">Call Rep. Blumenauer</button>
+            <button data-id="B000574" class="call-key-rep action-button">Call Rep. Blumenauer</button>
 
             <div style="clear: both;"></div>
 
@@ -193,7 +193,7 @@ title: Home
 
             </div>
 
-            <button data-id="B001278" class="call-key-rep">Call Rep. Bonamici</button>
+            <button data-id="B001278" class="call-key-rep action-button">Call Rep. Bonamici</button>
 
             <div style="clear: both;"></div>
 
@@ -215,7 +215,7 @@ title: Home
 
             </div>
 
-            <button data-id="C001078" class="call-key-rep">Call Rep. Connolly</button>
+            <button data-id="C001078" class="call-key-rep action-button">Call Rep. Connolly</button>
 
             <div style="clear: both;"></div>
 
@@ -237,7 +237,7 @@ title: Home
 
             </div>
 
-            <button data-id="C000754" class="call-key-rep">Call Rep. Cooper</button>
+            <button data-id="C000754" class="call-key-rep action-button">Call Rep. Cooper</button>
 
             <div style="clear: both;"></div>
 
@@ -259,7 +259,7 @@ title: Home
 
             </div>
 
-            <button data-id="C001059" class="call-key-rep">Call Rep. Costa</button>
+            <button data-id="C001059" class="call-key-rep action-button">Call Rep. Costa</button>
 
             <div style="clear: both;"></div>
 
@@ -281,7 +281,7 @@ title: Home
 
             </div>
 
-            <button data-id="C001063" class="call-key-rep">Call Rep. Cuellar</button>
+            <button data-id="C001063" class="call-key-rep action-button">Call Rep. Cuellar</button>
 
             <div style="clear: both;"></div>
 
@@ -303,7 +303,7 @@ title: Home
 
             </div>
 
-            <button data-id="D000598" class="call-key-rep">Call Rep. Davis</button>
+            <button data-id="D000598" class="call-key-rep action-button">Call Rep. Davis</button>
 
             <div style="clear: both;"></div>
 
@@ -325,7 +325,7 @@ title: Home
 
             </div>
 
-            <button data-id="D000620" class="call-key-rep">Call Rep. Delaney</button>
+            <button data-id="D000620" class="call-key-rep action-button">Call Rep. Delaney</button>
 
             <div style="clear: both;"></div>
 
@@ -347,7 +347,7 @@ title: Home
 
             </div>
 
-            <button data-id="D000617" class="call-key-rep">Call Rep. DelBene</button>
+            <button data-id="D000617" class="call-key-rep action-button">Call Rep. DelBene</button>
 
             <div style="clear: both;"></div>
 
@@ -369,7 +369,7 @@ title: Home
 
             </div>
 
-            <button data-id="F000030" class="call-key-rep">Call Rep. Farr</button>
+            <button data-id="F000030" class="call-key-rep action-button">Call Rep. Farr</button>
 
             <div style="clear: both;"></div>
 
@@ -391,7 +391,7 @@ title: Home
 
             </div>
 
-            <button data-id="H001047" class="call-key-rep">Call Rep. Himes</button>
+            <button data-id="H001047" class="call-key-rep action-button">Call Rep. Himes</button>
 
             <div style="clear: both;"></div>
 
@@ -413,7 +413,7 @@ title: Home
 
             </div>
 
-            <button data-id="H000636" class="call-key-rep">Call Rep. Hinojosa</button>
+            <button data-id="H000636" class="call-key-rep action-button">Call Rep. Hinojosa</button>
 
             <div style="clear: both;"></div>
 
@@ -435,7 +435,7 @@ title: Home
 
             </div>
 
-            <button data-id="J000126" class="call-key-rep">Call Rep. Johnson</button>
+            <button data-id="J000126" class="call-key-rep action-button">Call Rep. Johnson</button>
 
             <div style="clear: both;"></div>
 
@@ -457,7 +457,7 @@ title: Home
 
             </div>
 
-            <button datai-d="K000381" class="call-key-rep">Call Rep. Kilmer</button>
+            <button datai-d="K000381" class="call-key-rep action-button">Call Rep. Kilmer</button>
 
             <div style="clear: both;"></div>
 
@@ -479,7 +479,7 @@ title: Home
 
             </div>
 
-            <button data-id="K000188" class="call-key-rep">Call Rep. Kind</button>
+            <button data-id="K000188" class="call-key-rep action-button">Call Rep. Kind</button>
 
             <div style="clear: both;"></div>
 
@@ -501,7 +501,7 @@ title: Home
 
             </div>
 
-            <button data-id="L000560" class="call-key-rep">Call Rep. Larsen</button>
+            <button data-id="L000560" class="call-key-rep action-button">Call Rep. Larsen</button>
 
             <div style="clear: both;"></div>
 
@@ -523,7 +523,7 @@ title: Home
 
             </div>
 
-            <button data-id="M001137" class="call-key-rep">Call Rep. Meeks</button>
+            <button data-id="M001137" class="call-key-rep action-button">Call Rep. Meeks</button>
 
             <div style="clear: both;"></div>
 
@@ -545,7 +545,7 @@ title: Home
 
             </div>
 
-            <button data-id="O000170" class="call-key-rep">Call Rep. O'Rourke</button>
+            <button data-id="O000170" class="call-key-rep action-button">Call Rep. O'Rourke</button>
 
             <div style="clear: both;"></div>
 
@@ -567,7 +567,7 @@ title: Home
 
             </div>
 
-            <button data-id="P000608" class="call-key-rep">Call Rep. Peters</button>
+            <button data-id="P000608" class="call-key-rep action-button">Call Rep. Peters</button>
 
             <div style="clear: both;"></div>
 
@@ -589,7 +589,7 @@ title: Home
 
             </div>
 
-            <button data-id="P000598" class="call-key-rep">Call Rep. Polis</button>
+            <button data-id="P000598" class="call-key-rep action-button">Call Rep. Polis</button>
 
             <div style="clear: both;"></div>
 
@@ -611,7 +611,7 @@ title: Home
 
             </div>
 
-            <button data-id="Q000023" class="call-key-rep">Call Rep. Quigley</button>
+            <button data-id="Q000023" class="call-key-rep action-button">Call Rep. Quigley</button>
 
             <div style="clear: both;"></div>
 
@@ -633,7 +633,7 @@ title: Home
 
             </div>
 
-            <button data-id="R000602" class="call-key-rep">Call Rep. Rice</button>
+            <button data-id="R000602" class="call-key-rep action-button">Call Rep. Rice</button>
 
             <div style="clear: both;"></div>
 
@@ -655,7 +655,7 @@ title: Home
 
             </div>
 
-            <button data-id="S001180" class="call-key-rep">Call Rep. Schrader</button>
+            <button data-id="S001180" class="call-key-rep action-button">Call Rep. Schrader</button>
 
             <div style="clear: both;"></div>
 
@@ -677,7 +677,7 @@ title: Home
 
             </div>
 
-            <button data-id="S001185" class="call-key-rep">Call Rep. Sewell</button>
+            <button data-id="S001185" class="call-key-rep action-button">Call Rep. Sewell</button>
 
             <div style="clear: both;"></div>
 
@@ -699,7 +699,7 @@ title: Home
 
             </div>
 
-            <button data-id="W000797" class="call-key-rep">Call Rep. Wasserman Schultz</button>
+            <button data-id="W000797" class="call-key-rep action-button">Call Rep. Wasserman Schultz</button>
 
             <div style="clear: both;"></div>
 


### PR DESCRIPTION
This should fix that bioguide_id error you were having I think?

You want to re-use the class name for the buttons on the front page and on the overlay as well, so I changed that name from "call-key-rep" to "action-button". That way you have a separate meaning for the styling vs the action. You select on "call-key-rep" for login in the javascript, but you select on "action-button" for the styling. That way you can re-use "action-button" in the overlay where you want to keep the styling, but not the event handler logic.
